### PR TITLE
fix improper dihedrals

### DIFF
--- a/src/gromacs/listed_forces/bonded.cpp
+++ b/src/gromacs/listed_forces/bonded.cpp
@@ -1837,8 +1837,12 @@ void do_dih_fup(int            i,
         rvec_inc(f[l], f_l);           /*  3	*/
 
         if (fda) {
+            rvec_opp(f_j);
+            rvec_opp(f_k);
             fda->add_dihedral(i, j, k, l, f_i, f_j, f_k, f_l);
             fda->add_virial_dihedral(i, j, k, l, f_i, f_k, f_l, r_ij, r_kj, r_kl);
+            rvec_opp(f_j);
+            rvec_opp(f_k);
         }
 
         if (computeVirial(flavor))


### PR DESCRIPTION
`f_j` and `f_k` happen to have the opposite sign as `f_i` and `f_l`, which can be seen from the `rvec_inc` and `rvec_dec` calls above.